### PR TITLE
hotfix(v1.1.1): 라인업 API 타순 0인 선수 필터링 수정

### DIFF
--- a/src/main/java/academy/cheerlot/lineup/LineupController.java
+++ b/src/main/java/academy/cheerlot/lineup/LineupController.java
@@ -47,8 +47,9 @@ public class LineupController {
         }
         
         Team team = teamOpt.get();
-        List<Player> players = playerRepository.findByTeamCodeOrderByBatsOrder(teamCode);
-        List<PlayerDto> playerDtos = players.stream()
+        List<Player> allPlayers = playerRepository.findByTeamCodeOrderByBatsOrder(teamCode);
+        List<PlayerDto> playerDtos = allPlayers.stream()
+                .filter(player -> !"0".equals(player.getBatsOrder()))
                 .map(this::convertToDto)
                 .toList();
 


### PR DESCRIPTION
## 문제
  - `/api/lineups/{teamCode}` 호출 시 타순이 0인 선수들도 함께 반환되는
  문제
  - 실제 라인업에는 타순이 0이 아닌 선수들만 포함되어야 함

  ## 해결
  - `LineupController`에서 Stream filter 적용
  - 타순이 "0"이 아닌 선수들만 반환하도록 수정
  - Repository 계층은 단순하게 유지하고 Controller에서 필터링

  ## 테스트
  - [x] API 호출 시 타순 0인 선수 제외 확인
  - [x] 컴파일 및 빌드 정상 동작 확인

  ## 버전
  - v1.1.1 (패치 버전)