### PR TITLE
🐛 Fix: #38 어드민 페이지 500 에러 수정

### DIFF
--- a/src/main/java/academy/cheerlot/admin/AdminController.java
+++ b/src/main/java/academy/cheerlot/admin/AdminController.java
@@ -145,17 +145,25 @@ public class AdminController {
         try {
             ClassPathResource resource = new ClassPathResource("cheersongs/audio");
             if (resource.exists()) {
-                Path audioPath = Paths.get(resource.getURI());
-                Files.list(audioPath)
-                    .filter(path -> path.toString().toLowerCase().endsWith(".mp3") || 
-                                   path.toString().toLowerCase().endsWith(".mp4"))
-                    .forEach(path -> {
-                        String fileName = path.getFileName().toString();
-                        fileMap.put(fileName, fileName);
-                    });
+                if (resource.getURI().toString().startsWith("jar:")) {
+                    // JAR 파일 내부에서 실행될 때 (Docker 컨테이너)
+                    // 실제로는 리소스 폴더의 파일 목록을 하드코딩하거나 다른 방식으로 관리해야 함
+                    // 임시로 빈 맵 반환 (응원가 파일이 없다고 표시됨)
+                    System.out.println("Running in JAR mode - cheersong file listing not available");
+                } else {
+                    // 개발 환경에서 실행될 때
+                    Path audioPath = Paths.get(resource.getURI());
+                    Files.list(audioPath)
+                        .filter(path -> path.toString().toLowerCase().endsWith(".mp3") || 
+                                       path.toString().toLowerCase().endsWith(".mp4"))
+                        .forEach(path -> {
+                            String fileName = path.getFileName().toString();
+                            fileMap.put(fileName, fileName);
+                        });
+                }
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            System.out.println("Error accessing cheersong files: " + e.getMessage());
         }
         return fileMap;
     }

--- a/src/main/resources/templates/admin/players.html
+++ b/src/main/resources/templates/admin/players.html
@@ -174,7 +174,7 @@
                         <tbody>
                             <tr th:each="player : ${players}">
                                 <td>
-                                    <span class="badge bg-info" th:text="${player.team.teamCode}">팀코드</span>
+                                    <span class="badge bg-info" th:text="${player.teamCode}">팀코드</span>
                                 </td>
                                 <td>
                                     <strong th:text="${player.name}">선수명</strong>
@@ -188,24 +188,24 @@
                                     <input type="number" 
                                            class="batting-order-input" 
                                            th:value="${player.batsOrder}" 
-                                           th:data-player-id="${player.id}"
+                                           th:data-player-id="${player.playerId}"
                                            min="0" max="9"
                                            onchange="updateBattingOrder(this)">
                                 </td>
                                 <td>
-                                    <span th:if="${cheerSongFiles.containsKey(player.team.teamCode.toLowerCase() + player.backNumber + '.mp3')}" 
+                                    <span th:if="${cheerSongFiles.containsKey(player.teamCode.toLowerCase() + player.backNumber + '.mp3')}" 
                                           class="cheersong-indicator">
                                         <i class="bi bi-music-note-beamed"></i> 있음
                                     </span>
-                                    <span th:unless="${cheerSongFiles.containsKey(player.team.teamCode.toLowerCase() + player.backNumber + '.mp3')}" 
+                                    <span th:unless="${cheerSongFiles.containsKey(player.teamCode.toLowerCase() + player.backNumber + '.mp3')}" 
                                           class="no-cheersong">
                                         <i class="bi bi-music-note"></i> 없음
                                     </span>
                                 </td>
                                 <td>
                                     <button class="btn btn-sm btn-outline-primary play-cheersong-btn" 
-                                            th:data-filename="${player.team.teamCode.toLowerCase() + player.backNumber + '.mp3'}"
-                                            th:disabled="${!cheerSongFiles.containsKey(player.team.teamCode.toLowerCase() + player.backNumber + '.mp3')}">
+                                            th:data-filename="${player.teamCode.toLowerCase() + player.backNumber + '.mp3'}"
+                                            th:disabled="${!cheerSongFiles.containsKey(player.teamCode.toLowerCase() + player.backNumber + '.mp3')}">
                                         <i class="bi bi-play"></i>
                                     </button>
                                 </td>


### PR DESCRIPTION

<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #38 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

  - Thymeleaf 템플릿에서 잘못된 객체 참조 수정 (`player.team.teamCode` → `player.teamCode`)
  - Player 엔티티 필드명 수정 (`player.id` → `player.playerId`)
  - Docker 컨테이너 환경에서 JAR 내부 리소스 접근 시 안전성 개선
  - AdminController의 응원가 파일 매핑 로직 예외 처리 강화

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

  **수정 전**: Whitelabel Error Page (500 Internal Server Error)
  **수정 후**: 어드민 페이지 정상 렌더링 (총 399명 선수 데이터 표시)

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

  - [x] `http://localhost:8080/admin/players` 페이지 정상 접근 확인
  - [x] Docker 컨테이너 환경에서 HTTP 200 응답 확인
  - [x] 선수 데이터 목록 정상 렌더링 확인
  - [x] 팀별 필터링 기능 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

  - Player 엔티티에는 `team` 객체가 없고 `teamCode` 필드만 존재하므로, 템플릿에서 직접 참조하도록 수정
  - JAR 환경에서는 ClassPathResource로 파일 목록을 직접 읽을 수 없어서 임시로 빈 맵을 반환하도록 처리 (응원가 파일 관리는 후속 개선 필요)
  - 개발 환경에서는 기존 로직이 정상 동작함

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

  - `AdminController.getCheersongFileMap()` 메서드의 JAR 환경 처리 로직
  - Thymeleaf 템플릿에서 Player 엔티티 필드 접근 방식