### PR TITLE
✨ Feat: #39 버전 관리 시스템 개선 및 관리자 페이지 추가

### DIFF
--- a/src/main/java/academy/cheerlot/lineup/LineupCrawlerService.java
+++ b/src/main/java/academy/cheerlot/lineup/LineupCrawlerService.java
@@ -236,24 +236,40 @@ public class LineupCrawlerService {
     private void updateTeamInfo(Team homeTeam, Team awayTeam) {
         LocalDate today = LocalDate.now();
         
-        homeTeam.setLastUpdated(today);
-        homeTeam.setLastOpponent(awayTeam.getName());
-        teamRepository.save(homeTeam);
+        boolean homeTeamUpdated = !today.equals(homeTeam.getLastUpdated()) || 
+                                  !awayTeam.getName().equals(homeTeam.getLastOpponent());
         
-        awayTeam.setLastUpdated(today);
-        awayTeam.setLastOpponent(homeTeam.getName());
-        teamRepository.save(awayTeam);
+        boolean awayTeamUpdated = !today.equals(awayTeam.getLastUpdated()) || 
+                                  !homeTeam.getName().equals(awayTeam.getLastOpponent());
         
-        updateTeamVersions(homeTeam, awayTeam);
+        if (homeTeamUpdated) {
+            homeTeam.setLastUpdated(today);
+            homeTeam.setLastOpponent(awayTeam.getName());
+            teamRepository.save(homeTeam);
+        }
+        
+        if (awayTeamUpdated) {
+            awayTeam.setLastUpdated(today);
+            awayTeam.setLastOpponent(homeTeam.getName());
+            teamRepository.save(awayTeam);
+        }
+        
+        if (homeTeamUpdated || awayTeamUpdated) {
+            updateTeamVersions(homeTeam, awayTeam, homeTeamUpdated, awayTeamUpdated);
+        }
         
     }
     
-    private void updateTeamVersions(Team homeTeam, Team awayTeam) {
+    private void updateTeamVersions(Team homeTeam, Team awayTeam, boolean homeTeamUpdated, boolean awayTeamUpdated) {
         String gameDescription = String.format("%s vs %s 라인업 업데이트", homeTeam.getName(), awayTeam.getName());
         
-        versionService.updateLineupVersion(homeTeam.getTeamCode(), gameDescription);
+        if (homeTeamUpdated) {
+            versionService.updateLineupVersion(homeTeam.getTeamCode(), gameDescription);
+        }
         
-        versionService.updateLineupVersion(awayTeam.getTeamCode(), gameDescription);
+        if (awayTeamUpdated) {
+            versionService.updateLineupVersion(awayTeam.getTeamCode(), gameDescription);
+        }
         
     }
 }

--- a/src/main/java/academy/cheerlot/version/Version.java
+++ b/src/main/java/academy/cheerlot/version/Version.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class Version {
 
     @Id
-    private String id; // teamCode:type 형태로 변경
+    private String id;
 
     @Indexed
     private String teamCode;
@@ -29,8 +29,8 @@ public class Version {
     private String description;
 
     public enum VersionType {
-        ROSTER,    // 선수명단 버전
-        LINEUP     // 라인업 버전
+        ROSTER,
+        LINEUP
     }
 
     public Version(String teamCode, VersionType type, String description) {
@@ -39,12 +39,12 @@ public class Version {
         this.type = type;
         this.description = description;
         this.lastUpdated = LocalDateTime.now();
-        this.versionNumber = System.currentTimeMillis();
+        this.versionNumber = 0L;
     }
 
-    public void updateVersion(String description) {
+    public void updateVersion(String description, Long newVersionNumber) {
         this.lastUpdated = LocalDateTime.now();
-        this.versionNumber = System.currentTimeMillis();
+        this.versionNumber = newVersionNumber;
         this.description = description;
     }
 }

--- a/src/main/java/academy/cheerlot/version/VersionService.java
+++ b/src/main/java/academy/cheerlot/version/VersionService.java
@@ -26,7 +26,8 @@ public class VersionService {
         
         if (existingVersion.isPresent()) {
             Version version = existingVersion.get();
-            version.updateVersion(description);
+            Long nextVersionNumber = version.getVersionNumber() + 1;
+            version.updateVersion(description, nextVersionNumber);
             return versionRepository.save(version);
         } else {
             Version newVersion = new Version(teamCode, type, description);
@@ -50,5 +51,19 @@ public class VersionService {
     @Transactional(readOnly = true)
     public Long getLineupVersionNumber(String teamCode) {
         return getVersionNumber(teamCode, Version.VersionType.LINEUP).orElse(0L);
+    }
+
+    public Version setVersionNumber(String teamCode, Version.VersionType type, String description, Long versionNumber) {
+        Optional<Version> existingVersion = versionRepository.findByTeamCodeAndType(teamCode, type);
+        
+        if (existingVersion.isPresent()) {
+            Version version = existingVersion.get();
+            version.updateVersion(description, versionNumber);
+            return versionRepository.save(version);
+        } else {
+            Version newVersion = new Version(teamCode, type, description);
+            newVersion.updateVersion(description, versionNumber);
+            return versionRepository.save(newVersion);
+        }
     }
 }

--- a/src/main/resources/templates/admin/cheersongs.html
+++ b/src/main/resources/templates/admin/cheersongs.html
@@ -143,6 +143,9 @@
             <a class="nav-link active" href="/admin/cheersongs">
                 <i class="bi bi-music-note"></i> 응원가 관리
             </a>
+            <a class="nav-link" href="/admin/versions">
+                <i class="bi bi-git"></i> 버전 관리
+            </a>
         </nav>
     </div>
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -107,6 +107,9 @@
             <a class="nav-link" href="/admin/cheersongs">
                 <i class="bi bi-music-note"></i> 응원가 관리
             </a>
+            <a class="nav-link" href="/admin/versions">
+                <i class="bi bi-git"></i> 버전 관리
+            </a>
         </nav>
     </div>
 

--- a/src/main/resources/templates/admin/lineup.html
+++ b/src/main/resources/templates/admin/lineup.html
@@ -125,6 +125,9 @@
             <a class="nav-link" href="/admin/cheersongs">
                 <i class="bi bi-music-note"></i> 응원가 관리
             </a>
+            <a class="nav-link" href="/admin/versions">
+                <i class="bi bi-git"></i> 버전 관리
+            </a>
         </nav>
     </div>
 

--- a/src/main/resources/templates/admin/players.html
+++ b/src/main/resources/templates/admin/players.html
@@ -116,6 +116,9 @@
             <a class="nav-link" href="/admin/cheersongs">
                 <i class="bi bi-music-note"></i> 응원가 관리
             </a>
+            <a class="nav-link" href="/admin/versions">
+                <i class="bi bi-git"></i> 버전 관리
+            </a>
         </nav>
     </div>
 

--- a/src/main/resources/templates/admin/versions.html
+++ b/src/main/resources/templates/admin/versions.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>버전 관리 - CheerLot 관리자</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css" rel="stylesheet">
+    <style>
+        .sidebar {
+            height: 100vh;
+            background: linear-gradient(180deg, #2c3e50 0%, #34495e 100%);
+            color: white;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 250px;
+            z-index: 1000;
+        }
+        .main-content {
+            margin-left: 250px;
+            padding: 20px;
+            min-height: 100vh;
+            background-color: #f8f9fa;
+        }
+        .nav-link {
+            color: #ecf0f1 !important;
+            padding: 12px 20px;
+            border-radius: 8px;
+            margin: 5px 15px;
+            transition: all 0.3s ease;
+        }
+        .nav-link:hover, .nav-link.active {
+            background-color: #3498db;
+            color: white !important;
+            transform: translateX(5px);
+        }
+        .nav-link i {
+            margin-right: 10px;
+            width: 20px;
+            text-align: center;
+        }
+        .brand {
+            padding: 20px;
+            border-bottom: 1px solid #34495e;
+            text-align: center;
+        }
+        .brand h4 {
+            color: #3498db;
+            font-weight: bold;
+            margin: 0;
+        }
+        .card {
+            border: none;
+            border-radius: 15px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .table {
+            border-radius: 10px;
+            overflow: hidden;
+        }
+        .table thead th {
+            background: linear-gradient(45deg, #3498db, #2980b9);
+            color: white;
+            border: none;
+            font-weight: 600;
+        }
+        .version-badge {
+            border-radius: 20px;
+            padding: 8px 12px;
+            font-size: 0.8em;
+        }
+        .version-number {
+            font-family: 'Courier New', monospace;
+            font-size: 0.9em;
+        }
+        .update-btn {
+            padding: 4px 8px;
+            font-size: 0.8em;
+        }
+        @media (max-width: 768px) {
+            .sidebar {
+                width: 100%;
+                height: auto;
+                position: relative;
+            }
+            .main-content {
+                margin-left: 0;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="sidebar">
+        <div class="brand">
+            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
+            <small class="text-muted">관리자 페이지</small>
+        </div>
+        <nav class="nav flex-column">
+            <a class="nav-link" href="/admin">
+                <i class="bi bi-speedometer2"></i> 대시보드
+            </a>
+            <a class="nav-link" href="/admin/players">
+                <i class="bi bi-people"></i> 전체 선수 명단
+            </a>
+            <a class="nav-link" href="/admin/lineup">
+                <i class="bi bi-list-ol"></i> 선발 라인업
+            </a>
+            <a class="nav-link" href="/admin/cheersongs">
+                <i class="bi bi-music-note"></i> 응원가 관리
+            </a>
+            <a class="nav-link active" href="/admin/versions">
+                <i class="bi bi-git"></i> 버전 관리
+            </a>
+        </nav>
+    </div>
+
+    <div class="main-content">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1><i class="bi bi-git"></i> 버전 관리</h1>
+            <span class="badge bg-primary" th:text="'총 ' + ${#lists.size(teams)} + '개 팀'">총 0개 팀</span>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5><i class="bi bi-list-ul"></i> 팀별 버전 현황</h5>
+            </div>
+            <div class="card-body">
+                <div class="table-responsive">
+                    <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th>팀명</th>
+                                <th>팀코드</th>
+                                <th>로스터 버전</th>
+                                <th>로스터 업데이트</th>
+                                <th>라인업 버전</th>
+                                <th>라인업 업데이트</th>
+                                <th>작업</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:each="team : ${teams}">
+                                <td>
+                                    <strong th:text="${team.name}">팀명</strong>
+                                </td>
+                                <td>
+                                    <span class="badge bg-info" th:text="${team.teamCode}">팀코드</span>
+                                </td>
+                                <td>
+                                    <div th:if="${versionMap[team.teamCode] != null and versionMap[team.teamCode]['ROSTER'] != null}">
+                                        <span class="version-number" th:text="${versionMap[team.teamCode]['ROSTER'].versionNumber}">0</span>
+                                        <br>
+                                        <small class="text-muted" th:text="${#temporals.format(versionMap[team.teamCode]['ROSTER'].lastUpdated, 'yyyy-MM-dd HH:mm')}">날짜</small>
+                                    </div>
+                                    <span th:unless="${versionMap[team.teamCode] != null and versionMap[team.teamCode]['ROSTER'] != null}" class="text-muted">미설정</span>
+                                </td>
+                                <td>
+                                    <button class="btn btn-sm btn-outline-primary update-version-btn" 
+                                            th:data-team-code="${team.teamCode}"
+                                            th:data-version-type="roster"
+                                            data-bs-toggle="modal" 
+                                            data-bs-target="#updateVersionModal">
+                                        <i class="bi bi-arrow-clockwise"></i> 업데이트
+                                    </button>
+                                </td>
+                                <td>
+                                    <div th:if="${versionMap[team.teamCode] != null and versionMap[team.teamCode]['LINEUP'] != null}">
+                                        <span class="version-number" th:text="${versionMap[team.teamCode]['LINEUP'].versionNumber}">0</span>
+                                        <br>
+                                        <small class="text-muted" th:text="${#temporals.format(versionMap[team.teamCode]['LINEUP'].lastUpdated, 'yyyy-MM-dd HH:mm')}">날짜</small>
+                                    </div>
+                                    <span th:unless="${versionMap[team.teamCode] != null and versionMap[team.teamCode]['LINEUP'] != null}" class="text-muted">미설정</span>
+                                </td>
+                                <td>
+                                    <button class="btn btn-sm btn-outline-success update-version-btn" 
+                                            th:data-team-code="${team.teamCode}"
+                                            th:data-version-type="lineup"
+                                            data-bs-toggle="modal" 
+                                            data-bs-target="#updateVersionModal">
+                                        <i class="bi bi-arrow-clockwise"></i> 업데이트
+                                    </button>
+                                </td>
+                                <td>
+                                    <button class="btn btn-sm btn-outline-warning" 
+                                            onclick="updateAllVersions(this.dataset.teamCode)"
+                                            th:data-team-code="${team.teamCode}">
+                                        <i class="bi bi-arrow-repeat"></i> 전체
+                                    </button>
+                                </td>
+                            </tr>
+                            <tr th:if="${#lists.isEmpty(teams)}">
+                                <td colspan="7" class="text-center text-muted">등록된 팀이 없습니다.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 버전 업데이트 모달 -->
+    <div class="modal fade" id="updateVersionModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">버전 업데이트</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="updateVersionForm">
+                        <div class="mb-3">
+                            <label for="versionNumber" class="form-label">버전 번호</label>
+                            <input type="number" class="form-control" id="versionNumber" placeholder="예: 5" min="0" required>
+                            <div class="form-text">설정할 버전 번호를 입력하세요 (0 이상)</div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="versionDescription" class="form-label">업데이트 설명</label>
+                            <input type="text" class="form-control" id="versionDescription" placeholder="예: 선수 로스터 수정" required>
+                        </div>
+                        <input type="hidden" id="modalTeamCode">
+                        <input type="hidden" id="modalVersionType">
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                    <button type="button" class="btn btn-primary" onclick="submitVersionUpdate()">업데이트</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 토스트 알림 -->
+    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+        <div id="updateToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header">
+                <strong class="me-auto">알림</strong>
+                <button type="button" class="btn-close" data-bs-dismiss="toast"></button>
+            </div>
+            <div class="toast-body" id="toastMessage">
+                메시지가 여기에 표시됩니다.
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const updateButtons = document.querySelectorAll('.update-version-btn');
+            updateButtons.forEach(button => {
+                button.addEventListener('click', function() {
+                    document.getElementById('modalTeamCode').value = this.dataset.teamCode;
+                    document.getElementById('modalVersionType').value = this.dataset.versionType;
+                    document.getElementById('versionNumber').value = '';
+                    document.getElementById('versionDescription').value = '';
+                });
+            });
+        });
+
+        function submitVersionUpdate() {
+            const teamCode = document.getElementById('modalTeamCode').value;
+            const versionType = document.getElementById('modalVersionType').value;
+            const versionNumber = document.getElementById('versionNumber').value;
+            const description = document.getElementById('versionDescription').value;
+
+            if (!versionNumber || versionNumber < 0) {
+                showToast('버전 번호를 올바르게 입력해주세요. (0 이상)', 'danger');
+                return;
+            }
+
+            if (!description.trim()) {
+                showToast('업데이트 설명을 입력해주세요.', 'danger');
+                return;
+            }
+
+            fetch(`/admin/version/${teamCode}/${versionType}/update`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: `versionNumber=${encodeURIComponent(versionNumber)}&description=${encodeURIComponent(description)}`
+            })
+            .then(response => response.json())
+            .then(data => {
+                showToast(data.message, data.status === 'success' ? 'success' : 'danger');
+                if (data.status === 'success') {
+                    setTimeout(() => location.reload(), 1500);
+                }
+                bootstrap.Modal.getInstance(document.getElementById('updateVersionModal')).hide();
+            })
+            .catch(error => {
+                showToast('업데이트 중 오류가 발생했습니다.', 'danger');
+                console.error('Error:', error);
+            });
+        }
+
+        function updateAllVersions(teamCode) {
+            if (!confirm('해당 팀의 로스터와 라인업 버전을 모두 업데이트하시겠습니까?')) {
+                return;
+            }
+
+            const description = '관리자 수동 업데이트';
+            
+            Promise.all([
+                fetch(`/admin/version/${teamCode}/roster/increment`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: `description=${encodeURIComponent(description)}`
+                }),
+                fetch(`/admin/version/${teamCode}/lineup/increment`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: `description=${encodeURIComponent(description)}`
+                })
+            ])
+            .then(responses => Promise.all(responses.map(r => r.json())))
+            .then(results => {
+                const allSuccess = results.every(r => r.status === 'success');
+                showToast(
+                    allSuccess ? '모든 버전이 업데이트되었습니다.' : '일부 버전 업데이트에 실패했습니다.',
+                    allSuccess ? 'success' : 'warning'
+                );
+                if (allSuccess) {
+                    setTimeout(() => location.reload(), 1500);
+                }
+            })
+            .catch(error => {
+                showToast('업데이트 중 오류가 발생했습니다.', 'danger');
+                console.error('Error:', error);
+            });
+        }
+
+        function showToast(message, type) {
+            const toastElement = document.getElementById('updateToast');
+            const toastBody = document.getElementById('toastMessage');
+            const toast = new bootstrap.Toast(toastElement);
+            
+            toastBody.textContent = message;
+            toastElement.className = `toast ${type === 'success' ? 'bg-success' : type === 'warning' ? 'bg-warning' : 'bg-danger'} text-white`;
+            
+            toast.show();
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
  ## ✨ What's this PR?
  ### 📌 관련 이슈 (Related Issue)
  - Closes #39

  ---

  ### 🧶 주요 변경 내용 (Summary)

  - **버전 시스템 개선**: 타임스탬프 기반 → 0부터 시작하는 증가형 버전으로 변경
  - **관리자 페이지 신규 추가**: `/admin/versions` 버전 관리 전용 페이지 구현
  - **직접 버전 설정 기능**: 관리자가 원하는 버전 번호로 직접 설정 가능
  - **조건부 라인업 버전 업데이트**: 팀의 lastUpdated가 실제 변경될 때만 버전 업데이트
  - **초기 버전 자동 생성**: 모든 팀의 ROSTER/LINEUP 버전을 0으로 자동 초기화
  - **UI 네비게이션 개선**: 모든 관리자 페이지에 버전 관리 메뉴 추가
  - **입력 검증 강화**: 숫자만 입력 가능, 0 이상 값 검증

  ---

  ### 📸 스크린샷 (Optional)

  **버전 관리 페이지**: 팀별 ROSTER/LINEUP 버전을 한눈에 확인하고 관리 가능
  **버전 업데이트 모달**: 버전 번호 직접 입력과 설명 작성 기능

  ---

  ### 🧪 테스트 / 검증 내역

  - [x] `/admin/versions` 페이지 정상 렌더링 확인
  - [x] 초기 버전 0 자동 생성 동작 확인
  - [x] 버전 직접 설정 기능 (숫자 입력 검증 포함)
  - [x] 증가형 버전 업데이트 (+1씩 증가) 확인
  - [x] 조건부 라인업 버전 업데이트 로직 확인
  - [x] 모든 관리자 페이지 네비게이션 메뉴 추가 확인
  - [x] Docker 환경에서 정상 동작 확인

  ---

  ### 💬 기타 공유 사항

  - **기존 데이터 호환성**: 기존 타임스탬프 버전은 그대로 유지되며, 새로운 버전만 0부터 시작
  - **성능 최적화**: 라인업 크롤링 시 실제 변경이 있을 때만 버전 업데이트하여 불필요한 버전 생성 방지
  - **사용자 경험**: 숫자 입력 필드와 검증 로직으로 잘못된 버전 입력 방지
  - **확장성**: 향후 다른 버전 타입 추가 시 쉽게 확장 가능한 구조로 설계

  ---

  ### 🙇🏻‍♀️ 리뷰 가이드 (선택)

  - **Version 엔티티**: 버전 번호 초기화 및 업데이트 로직 변경사항
  - **VersionService**: 직접 버전 설정 vs 증가형 업데이트 메서드 분리
  - **LineupCrawlerService**: 조건부 버전 업데이트 로직의 효율성
  - **AdminController**: 버전 관리 페이지와 REST API 엔드포인트 구현
  - **versions.html**: 버전 관리 UI와 입력 검증 JavaScript 로직