### PR TITLE
📊 Feat: #48 Prometheus와 Grafana 모니터링 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 
 	implementation 'org.jsoup:jsoup:1.15.3'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,32 @@ services:
     depends_on:
       - redis
     restart: always
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: cheerlot-prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: cheerlot-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+    restart: always
+
+volumes:
+  grafana-data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'spring-boot-app'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s
+    
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,8 @@ logging.level.root=INFO
 logging.file.name=logs/kbolineup.log
 
 kbolineup.files.output-dir=lineups
+
+# Actuator Configuration for Prometheus
+management.endpoints.web.exposure.include=health,prometheus,metrics,info
+management.endpoint.health.show-details=always
+management.metrics.export.prometheus.enabled=true


### PR DESCRIPTION
## ✨ What's this PR?
  ### 📌 관련 이슈 (Related Issue)
  <!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
  - Closes #48

  ---

  ### 🧶 주요 변경 내용 (Summary)
  <!-- 이번 PR에서 작업한 핵심 변경사항을 작성해주세요 -->

  - Prometheus와 Grafana 기반 모니터링 시스템 구축
  - Spring Boot Actuator + Micrometer Prometheus 메트릭 수집 기능 추가
  - Docker Compose에 모니터링 서비스 (Prometheus, Grafana) 추가
  - 애플리케이션 성능, JVM, Redis 메트릭 수집 설정
  - Grafana 대시보드용 기본 관리자 계정 설정

  ---

  ### 📸 스크린샷 (Optional)
  <!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
  <!-- 접속 URL 정보 -->
  - Prometheus: http://localhost:9090
  - Grafana: http://localhost:3000 (admin/admin)
  - 메트릭 엔드포인트: http://localhost:8080/actuator/prometheus

  ---

  ### 🧪 테스트 / 검증 내역
  <!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

  - [x] Spring Boot Actuator 메트릭 노출 확인 (`/actuator/prometheus`)
  - [x] Prometheus 타겟 연결 및 메트릭 수집 확인
  - [x] Grafana 데이터 소스 연결 및 쿼리 테스트 완료
  - [x] Docker Compose 전체 스택 정상 구동 확인
  - [x] HTTP 요청, JVM 메모리, Redis 연결 메트릭 수집 확인

  ---

  ### 💬 기타 공유 사항
  <!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

  - 보안을 위해 운영 환경에서는 Grafana 기본 비밀번호 변경 필요
  - 추후 커스텀 메트릭 (크롤링 성공률, API 응답시간 등) 추가 예정
  - 알림 설정 및 대시보드 템플릿은 별도 이슈로 분리하여 진행 예정

  ---

  ### 🙇🏻‍♀️ 리뷰 가이드 (선택)
  <!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

  - `prometheus.yml` 설정의 스크래핑 간격 및 타겟 구성
  - `application.properties`의 Actuator 엔드포인트 노출 범위
  - `docker-compose.yml`의 서비스 간 네트워크 연결 구성