### PR TITLE
✨ feat: #51 팀별 오늘 경기 여부 추가

### DIFF
--- a/src/main/java/academy/cheerlot/config/RedisDataLoader.java
+++ b/src/main/java/academy/cheerlot/config/RedisDataLoader.java
@@ -51,16 +51,16 @@ public class RedisDataLoader implements CommandLineRunner {
 
     private void loadTeamData() {
         List<Team> teams = List.of(
-            new Team("SS", "삼성 라이온즈", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("LG", "LG 트윈스", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("HH", "한화 이글스", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("LT", "롯데 자이언츠", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("NC", "NC 다이노스", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("SK", "SSG 랜더스", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("OB", "두산 베어스", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("KT", "KT wiz", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("WO", "키움 히어로즈", LocalDate.of(2025, 1, 1), "로딩 중..."),
-            new Team("HT", "KIA 타이거즈", LocalDate.of(2025, 1, 1), "로딩 중...")
+            new Team("SS", "삼성", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("LG", "LG", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("HH", "한화", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("LT", "롯데", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("NC", "NC", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("SK", "SSG", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("OB", "두산", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("KT", "KT", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("WO", "키움", LocalDate.of(2025, 1, 1), "로딩 중..."),
+            new Team("HT", "KIA", LocalDate.of(2025, 1, 1), "로딩 중...")
         );
 
         teamRepository.saveAll(teams);

--- a/src/main/java/academy/cheerlot/lineup/LineupController.java
+++ b/src/main/java/academy/cheerlot/lineup/LineupController.java
@@ -59,6 +59,7 @@ public class LineupController {
         LineupResponse response = new LineupResponse(
                 lastUpdated,
                 team.getLastOpponent(),
+                team.getHasGameToday(),
                 playerResponses
         );
         

--- a/src/main/java/academy/cheerlot/lineup/LineupResponse.java
+++ b/src/main/java/academy/cheerlot/lineup/LineupResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record LineupResponse(
         String updated,
         String opponent,
+        Boolean hasGameToday,
         List<PlayerResponse> players
 ) {
 }

--- a/src/main/java/academy/cheerlot/team/Team.java
+++ b/src/main/java/academy/cheerlot/team/Team.java
@@ -24,6 +24,8 @@ public class Team {
     private String lastOpponent;
     
     private int playerCount;
+    
+    private Boolean hasGameToday;
 
     public Team(String teamCode, String name, LocalDate lastUpdated, String lastOpponent) {
         this.teamCode = teamCode;
@@ -31,5 +33,6 @@ public class Team {
         this.lastUpdated = lastUpdated;
         this.lastOpponent = lastOpponent;
         this.playerCount = 0;
+        this.hasGameToday = false;
     }
 }

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -165,7 +165,11 @@
                                     <div class="card-body">
                                         <div class="d-flex justify-content-between align-items-center mb-2">
                                             <h6 class="card-title mb-0" th:text="${team.name}">팀명</h6>
-                                            <span class="badge bg-secondary" th:text="${team.teamCode}">팀코드</span>
+                                            <div>
+                                                <span class="badge bg-secondary me-1" th:text="${team.teamCode}">팀코드</span>
+                                                <span th:class="${team.hasGameToday} ? 'badge bg-success' : 'badge bg-light text-dark'" 
+                                                      th:text="${team.hasGameToday} ? '경기있음' : '경기없음'">경기상태</span>
+                                            </div>
                                         </div>
                                         <p class="text-muted small mb-2">
                                             <i class="bi bi-calendar"></i> 최근 업데이트: 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

  - Team 엔티티에 hasGameToday Boolean 필드 추가
  - 크롤링 시 각 팀별 경기 상태 자동 업데이트
  - LineupResponse에 hasGameToday 필드 포함
  - 관리자 대시보드에 팀별 경기 상태 표시

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

  - Team 엔티티 hasGameToday 필드 정상 추가
  - 크롤링 시 경기 있는 팀만 true로 설정되는지 확인
  - LineupResponse API에 hasGameToday 포함 확인
  - 관리자 대시보드에서 "경기있음/경기없음" 배지 표시 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

  - 크롤링 시 모든 팀을 false로 초기화 후, 실제 경기가 있는 팀만 true로 설정하는
  방식으로 구현
  - 에러 발생 시에만 로그 출력하도록 최소화
  - 기존 코드 구조를 최대한 유지하며 심플하게 구현
