### PR TITLE
✨ Feat: Team 엔티티에 시즌 활성 상태 필드 추가

### DIFF
--- a/src/main/java/academy/cheerlot/lineup/LineupController.java
+++ b/src/main/java/academy/cheerlot/lineup/LineupController.java
@@ -60,6 +60,7 @@ public class LineupController {
                 lastUpdated,
                 team.getLastOpponent(),
                 team.getHasGameToday(),
+                team.getIsSeasonActive(),
                 playerResponses
         );
         

--- a/src/main/java/academy/cheerlot/lineup/LineupResponse.java
+++ b/src/main/java/academy/cheerlot/lineup/LineupResponse.java
@@ -8,6 +8,7 @@ public record LineupResponse(
         String updated,
         String opponent,
         Boolean hasGameToday,
+        Boolean isSeasonActive,
         List<PlayerResponse> players
 ) {
 }

--- a/src/main/java/academy/cheerlot/team/Team.java
+++ b/src/main/java/academy/cheerlot/team/Team.java
@@ -26,6 +26,8 @@ public class Team {
     private int playerCount;
     
     private Boolean hasGameToday;
+    
+    private Boolean isSeasonActive;
 
     public Team(String teamCode, String name, LocalDate lastUpdated, String lastOpponent) {
         this.teamCode = teamCode;
@@ -34,5 +36,6 @@ public class Team {
         this.lastOpponent = lastOpponent;
         this.playerCount = 0;
         this.hasGameToday = false;
+        this.isSeasonActive = true;
     }
 }


### PR DESCRIPTION
- isSeasonActive Boolean 필드 추가
- 생성자에서 기본값 true로 설정

<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #55

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

  - Team 엔티티에 `isSeasonActive` Boolean 필드 추가
  - 생성자에서 기본값 true로 설정하여 모든 팀이 시즌 활성 상태로 초기화

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

  - [x] Team 엔티티 필드 추가 확인
  - [x] 기본값 true 설정 동작 확인
  - [x] 기존 기능 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

  - 향후 Admin 대시보드에서 시즌 상태 토글 기능 추가 예정
  - 시즌 비활성 팀에 대한 크롤링 제외 로직은 후속 작업으로 진행

---