### PR TITLE
✨ Feat: #58 Admin 페이지 사이드바 컴포넌트화

### DIFF
--- a/src/main/resources/templates/admin/api-docs.html
+++ b/src/main/resources/templates/admin/api-docs.html
@@ -173,29 +173,7 @@
     </style>
 </head>
 <body>
-    <div class="sidebar">
-        <div class="brand">
-            <h4><i class="bi bi-trophy"></i> KBO CheerLot</h4>
-            <small class="text-muted">관리자 페이지</small>
-        </div>
-        <nav class="nav flex-column">
-            <a class="nav-link" href="/admin">
-                <i class="bi bi-speedometer2"></i> 대시보드
-            </a>
-            <a class="nav-link" href="/admin/players">
-                <i class="bi bi-people"></i> 전체 선수 명단
-            </a>
-            <a class="nav-link" href="/admin/lineup">
-                <i class="bi bi-list-ol"></i> 선발 라인업
-            </a>
-            <a class="nav-link" href="/admin/cheersongs">
-                <i class="bi bi-music-note"></i> 응원가 관리
-            </a>
-            <a class="nav-link active" href="/admin/api-docs">
-                <i class="bi bi-book"></i> API 명세서
-            </a>
-        </nav>
-    </div>
+    <div th:replace="~{fragments/sidebar :: sidebar(currentPage='api-docs')}"></div>
 
     <div class="main-content">
         <div class="row">

--- a/src/main/resources/templates/admin/cheersongs.html
+++ b/src/main/resources/templates/admin/cheersongs.html
@@ -125,32 +125,7 @@
     </style>
 </head>
 <body>
-    <div class="sidebar">
-        <div class="brand">
-            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
-            <small class="text-muted">관리자 페이지</small>
-        </div>
-        <nav class="nav flex-column">
-            <a class="nav-link" href="/admin">
-                <i class="bi bi-speedometer2"></i> 대시보드
-            </a>
-            <a class="nav-link" href="/admin/players">
-                <i class="bi bi-people"></i> 전체 선수 명단
-            </a>
-            <a class="nav-link" href="/admin/lineup">
-                <i class="bi bi-list-ol"></i> 선발 라인업
-            </a>
-            <a class="nav-link active" href="/admin/cheersongs">
-                <i class="bi bi-music-note"></i> 응원가 관리
-            </a>
-            <a class="nav-link" href="/admin/versions">
-                <i class="bi bi-git"></i> 버전 관리
-            </a>
-            <a class="nav-link" href="/admin/api-docs">
-                <i class="bi bi-book"></i> API 명세서
-            </a>
-        </nav>
-    </div>
+    <div th:replace="~{fragments/sidebar :: sidebar(currentPage='cheersongs')}"></div>
 
     <div class="main-content">
         <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -89,32 +89,7 @@
     </style>
 </head>
 <body>
-    <div class="sidebar">
-        <div class="brand">
-            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
-            <small class="text-muted">관리자 페이지</small>
-        </div>
-        <nav class="nav flex-column">
-            <a class="nav-link active" href="/admin">
-                <i class="bi bi-speedometer2"></i> 대시보드
-            </a>
-            <a class="nav-link" href="/admin/players">
-                <i class="bi bi-people"></i> 전체 선수 명단
-            </a>
-            <a class="nav-link" href="/admin/lineup">
-                <i class="bi bi-list-ol"></i> 선발 라인업
-            </a>
-            <a class="nav-link" href="/admin/cheersongs">
-                <i class="bi bi-music-note"></i> 응원가 관리
-            </a>
-            <a class="nav-link" href="/admin/versions">
-                <i class="bi bi-git"></i> 버전 관리
-            </a>
-            <a class="nav-link" href="/admin/api-docs">
-                <i class="bi bi-book"></i> API 명세서
-            </a>
-        </nav>
-    </div>
+    <div th:replace="~{fragments/sidebar :: sidebar(currentPage='dashboard')}"></div>
 
     <div class="main-content">
         <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/main/resources/templates/admin/lineup.html
+++ b/src/main/resources/templates/admin/lineup.html
@@ -107,27 +107,7 @@
     </style>
 </head>
 <body>
-    <div class="sidebar">
-        <div class="brand">
-            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
-            <small class="text-muted">관리자 페이지</small>
-        </div>
-        <nav class="nav flex-column">
-            <a class="nav-link" href="/admin">
-                <i class="bi bi-speedometer2"></i> 대시보드
-            </a>
-            <a class="nav-link" href="/admin/players">
-                <i class="bi bi-people"></i> 전체 선수 명단
-            </a>
-            <a class="nav-link active" href="/admin/lineup">
-                <i class="bi bi-list-ol"></i> 선발 라인업
-            </a>
-            <a class="nav-link" href="/admin/cheersongs">
-                <i class="bi bi-music-note"></i> 응원가 관리
-            </a>
-            <a class="nav-link" href="/admin/versions">
-                <i class="bi bi-git"></i> 버전 관리
-            </a>
+    <div th:replace="~{fragments/sidebar :: sidebar(currentPage='lineup')}"></div>
             <a class="nav-link" href="/admin/api-docs">
                 <i class="bi bi-book"></i> API 명세서
             </a>

--- a/src/main/resources/templates/admin/players.html
+++ b/src/main/resources/templates/admin/players.html
@@ -98,32 +98,7 @@
     </style>
 </head>
 <body>
-    <div class="sidebar">
-        <div class="brand">
-            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
-            <small class="text-muted">관리자 페이지</small>
-        </div>
-        <nav class="nav flex-column">
-            <a class="nav-link" href="/admin">
-                <i class="bi bi-speedometer2"></i> 대시보드
-            </a>
-            <a class="nav-link active" href="/admin/players">
-                <i class="bi bi-people"></i> 전체 선수 명단
-            </a>
-            <a class="nav-link" href="/admin/lineup">
-                <i class="bi bi-list-ol"></i> 선발 라인업
-            </a>
-            <a class="nav-link" href="/admin/cheersongs">
-                <i class="bi bi-music-note"></i> 응원가 관리
-            </a>
-            <a class="nav-link" href="/admin/versions">
-                <i class="bi bi-git"></i> 버전 관리
-            </a>
-            <a class="nav-link" href="/admin/api-docs">
-                <i class="bi bi-book"></i> API 명세서
-            </a>
-        </nav>
-    </div>
+    <div th:replace="~{fragments/sidebar :: sidebar(currentPage='players')}"></div>
 
     <div class="main-content">
         <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/main/resources/templates/admin/versions.html
+++ b/src/main/resources/templates/admin/versions.html
@@ -91,32 +91,7 @@
     </style>
 </head>
 <body>
-    <div class="sidebar">
-        <div class="brand">
-            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
-            <small class="text-muted">관리자 페이지</small>
-        </div>
-        <nav class="nav flex-column">
-            <a class="nav-link" href="/admin">
-                <i class="bi bi-speedometer2"></i> 대시보드
-            </a>
-            <a class="nav-link" href="/admin/players">
-                <i class="bi bi-people"></i> 전체 선수 명단
-            </a>
-            <a class="nav-link" href="/admin/lineup">
-                <i class="bi bi-list-ol"></i> 선발 라인업
-            </a>
-            <a class="nav-link" href="/admin/cheersongs">
-                <i class="bi bi-music-note"></i> 응원가 관리
-            </a>
-            <a class="nav-link active" href="/admin/versions">
-                <i class="bi bi-git"></i> 버전 관리
-            </a>
-            <a class="nav-link" href="/admin/api-docs">
-                <i class="bi bi-book"></i> API 명세서
-            </a>
-        </nav>
-    </div>
+    <div th:replace="~{fragments/sidebar :: sidebar(currentPage='versions')}"></div>
 
     <div class="main-content">
         <div class="d-flex justify-content-between align-items-center mb-4">

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+    <div th:fragment="sidebar" class="sidebar">
+        <div class="brand">
+            <h4><i class="bi bi-trophy"></i> CheerLot</h4>
+            <small class="text-muted">관리자 페이지</small>
+        </div>
+        <nav class="nav flex-column">
+            <a class="nav-link" th:classappend="${currentPage == 'dashboard' ? 'active' : ''}" href="/admin">
+                <i class="bi bi-speedometer2"></i> 대시보드
+            </a>
+            <a class="nav-link" th:classappend="${currentPage == 'players' ? 'active' : ''}" href="/admin/players">
+                <i class="bi bi-people"></i> 전체 선수 명단
+            </a>
+            <a class="nav-link" th:classappend="${currentPage == 'lineup' ? 'active' : ''}" href="/admin/lineup">
+                <i class="bi bi-list-ol"></i> 선발 라인업
+            </a>
+            <a class="nav-link" th:classappend="${currentPage == 'cheersongs' ? 'active' : ''}" href="/admin/cheersongs">
+                <i class="bi bi-music-note"></i> 응원가 관리
+            </a>
+            <a class="nav-link" th:classappend="${currentPage == 'versions' ? 'active' : ''}" href="/admin/versions">
+                <i class="bi bi-git"></i> 버전 관리
+            </a>
+            <a class="nav-link" th:classappend="${currentPage == 'api-docs' ? 'active' : ''}" href="/admin/api-docs">
+                <i class="bi bi-book"></i> API 명세서
+            </a>
+        </nav>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## ✨ What's this PR?
  ### 📌 관련 이슈 (Related Issue)
  - Closes #58

  ---

  ### 🧶 주요 변경 내용 (Summary)

  - `fragments/sidebar.html` 공통 사이드바 fragment 생성
  - 모든 admin 페이지에서 중복된 사이드바 코드 제거 (6개 페이지)
  - `currentPage` 파라미터로 활성 메뉴 표시 기능 구현
  - 코드 중복 제거로 유지보수성 향상 (148줄 → 37줄)

  ---

  ### 📸 스크린샷 (Optional)
  <!-- 기존과 동일한 UI이므로 스크린샷 생략 -->

  ---

  ### 🧪 테스트 / 검증 내역

  - [x] 모든 admin 페이지에서 사이드바 정상 렌더링 확인
  - [x] 각 페이지별 활성 메뉴 하이라이트 정상 동작
  - [x] 기존 사이드바 기능 및 스타일링 유지 확인
  - [x] Thymeleaf fragment 문법 정상 동작 검증

  ---

  ### 💬 기타 공유 사항

  - 기존 페이지들의 사이드바 코드가 완전히 동일했어서 fragment로 분리하기 적합했습니다
  - `currentPage` 파라미터를 통해 각 페이지에서 해당 메뉴가 활성화되도록 구현했습니다
  - 향후 사이드바 메뉴 변경 시 fragment 파일 하나만 수정하면 모든 페이지에 반영됩니다

  ---

  ### 🙇🏻‍♀️ 리뷰 가이드 (선택)

  - `fragments/sidebar.html`의 Thymeleaf fragment 구조
  - 각 admin 페이지에서 fragment 호출 시 `currentPage` 파라미터 전달 방식