### PR TITLE
✨ Feat: #59 Admin 페이지 Team 시즌 활성 상태 관리 기능 구현

### DIFF
--- a/src/main/java/academy/cheerlot/admin/AdminController.java
+++ b/src/main/java/academy/cheerlot/admin/AdminController.java
@@ -271,6 +271,32 @@ public class AdminController {
         return response;
     }
 
+    @PostMapping("/team/{teamCode}/season-active")
+    @ResponseBody
+    public Map<String, String> toggleSeasonActive(@PathVariable String teamCode) {
+        Map<String, String> response = new HashMap<>();
+        try {
+            Team team = teamRepository.findById(teamCode).orElse(null);
+            if (team != null) {
+                Boolean currentStatus = team.getIsSeasonActive();
+                team.setIsSeasonActive(currentStatus == null ? true : !currentStatus);
+                teamRepository.save(team);
+                
+                String status = team.getIsSeasonActive() ? "활성" : "비활성";
+                response.put("status", "success");
+                response.put("message", team.getName() + " 팀의 시즌 상태가 " + status + "로 변경되었습니다.");
+                response.put("isActive", team.getIsSeasonActive().toString());
+            } else {
+                response.put("status", "error");
+                response.put("message", "팀을 찾을 수 없습니다.");
+            }
+        } catch (Exception e) {
+            response.put("status", "error");
+            response.put("message", "시즌 상태 변경 중 오류가 발생했습니다: " + e.getMessage());
+        }
+        return response;
+    }
+
     private List<Player> getPlayersWithCheersongs() {
         Map<String, String> cheerSongFiles = getCheersongFileMap();
         return ((List<Player>) playerRepository.findAll()).stream()

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -146,6 +146,22 @@
                                                       th:text="${team.hasGameToday} ? '경기있음' : '경기없음'">경기상태</span>
                                             </div>
                                         </div>
+                                        <div class="d-flex justify-content-between align-items-center mb-2">
+                                            <small class="text-muted">시즌 상태</small>
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input season-toggle" 
+                                                       type="checkbox" 
+                                                       th:checked="${team.isSeasonActive != null && team.isSeasonActive}"
+                                                       th:data-team-code="${team.teamCode}"
+                                                       th:data-team-name="${team.name}"
+                                                       th:id="'seasonToggle_' + ${team.teamCode}">
+                                                <label class="form-check-label" 
+                                                       th:for="'seasonToggle_' + ${team.teamCode}"
+                                                       th:text="${team.isSeasonActive != null && team.isSeasonActive ? '활성' : '비활성'}">
+                                                    상태
+                                                </label>
+                                            </div>
+                                        </div>
                                         <p class="text-muted small mb-2">
                                             <i class="bi bi-calendar"></i> 최근 업데이트: 
                                             <span th:text="${team.lastUpdated != null ? #temporals.format(team.lastUpdated, 'MM-dd') : 'N/A'}">N/A</span>
@@ -203,5 +219,68 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        function toggleSeasonActive(teamCode, teamName, toggle) {
+            fetch(`/admin/team/${teamCode}/season-active`, {
+                method: 'POST'
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    const label = toggle.nextElementSibling;
+                    label.textContent = data.isActive === 'true' ? '활성' : '비활성';
+                    showToast(data.message, 'success');
+                } else {
+                    toggle.checked = !toggle.checked;
+                    showToast(data.message, 'danger');
+                }
+            })
+            .catch(error => {
+                toggle.checked = !toggle.checked;
+                showToast('시즌 상태 변경 중 오류가 발생했습니다.', 'danger');
+                console.error('Error:', error);
+            });
+        }
+
+        function showToast(message, type) {
+            const toastContainer = document.querySelector('.toast-container') || createToastContainer();
+            const toastId = 'toast_' + Date.now();
+            
+            const toastHTML = `
+                <div id="${toastId}" class="toast ${type === 'success' ? 'bg-success' : 'bg-danger'} text-white" role="alert">
+                    <div class="toast-header">
+                        <strong class="me-auto">알림</strong>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast"></button>
+                    </div>
+                    <div class="toast-body">${message}</div>
+                </div>
+            `;
+            
+            toastContainer.insertAdjacentHTML('beforeend', toastHTML);
+            const toast = new bootstrap.Toast(document.getElementById(toastId));
+            toast.show();
+            
+            setTimeout(() => {
+                document.getElementById(toastId)?.remove();
+            }, 5000);
+        }
+
+        function createToastContainer() {
+            const container = document.createElement('div');
+            container.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+            document.body.appendChild(container);
+            return container;
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            document.addEventListener('change', function(e) {
+                if (e.target.classList.contains('season-toggle')) {
+                    const teamCode = e.target.dataset.teamCode;
+                    const teamName = e.target.dataset.teamName;
+                    toggleSeasonActive(teamCode, teamName, e.target);
+                }
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
  ## ✨ What's this PR?
  ### 📌 관련 이슈 (Related Issue)
  - Closes #59

  ---

  ### 🧶 주요 변경 내용 (Summary)

  - 팀 시즌 상태 토글 API 엔드포인트 구현
  - Admin 대시보드에 Bootstrap Switch 토글 UI 추가
  - 실시간 상태 변경 및 Toast 알림 기능 구현
  - 에러 처리 및 UI 상태 롤백 로직 추가

  ---

  ### 🧪 테스트 / 검증 내역

  - [x] 팀 시즌 상태 토글 API 정상 동작 확인
  - [x] Bootstrap Switch UI 정상 동작 확인
  - [x] Toast 알림 및 에러 처리 확인

  ---

  ### 💬 기타 공유 사항

  - Bootstrap Switch로 직관적인 토글 UI 제공
  - 에러 발생 시 토글 상태 자동 롤백
  - 팀별 시즌 상태를 대시보드에서 쉽게 관리 가능